### PR TITLE
feat(cli): `dist-tag-esm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ If you installed `dist-tag` locally, you may need to update your `PATH`:
 [ -d $PWD/node_modules/.bin ] && export PATH=$PWD/node_modules/.bin:$PATH
 ```
 
+#### CLI (ESM)
+
+```sh
+Usage
+  $ dist-tag-esm [target] [options]
+
+Options
+  -d, --delimiter Lookup target separator
+  -v, --version Displays current version
+  -h, --help Displays this message
+
+Examples
+  $ dist-tag-esm                                         # ''
+  $ dist-tag-esm 2.0.0                                   # ''
+  $ dist-tag-esm 2.0.0-alpha.1                           # 'alpha'
+  $ dist-tag-esm foo-package@2.0.0-beta.1 --delimiter @  # 'beta'
+  $ dist-tag-esm $(git describe --tags --abbrev=0) -d @  # depends on the tag 😉
+```
+
 ### Node.js
 
 ```typescript

--- a/build.config.ts
+++ b/build.config.ts
@@ -126,7 +126,7 @@ const config: BuildConfig = defineBuildConfig({
     cjsBridge: true,
     commonjs: { extensions: ['.cjs', '.js'] },
     emitCJS: true,
-    esbuild: { logLevel: 'info', minify: true },
+    esbuild: { logLevel: 'info', minify: true, target: 'esnext' },
     inlineDependencies: true,
     json: { compact: true },
     resolve: {}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "dist",
     "src"
   ],
-  "bin": "./dist/cli.cjs",
+  "bin": {
+    "dist-tag": "./dist/cli.cjs",
+    "dist-tag-esm": "./dist/cli.mjs"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,22 +6,44 @@
  */
 
 import type mri from 'mri'
+import path from 'node:path'
 import sade from 'sade'
-import { description, name, version } from '../package.json'
+import { description, version } from '../package.json'
 import type Flags from './flags'
 import lookup from './node'
+
+/* c8 ignore start */
+
+/**
+ * CLI filename.
+ *
+ * @const {string} filename
+ */
+const filename: string = process.argv[1] ?? ''
+
+/**
+ * CLI program name.
+ *
+ * @var {string} name
+ */
+let name: string = 'dist-tag'
+
+// update cli program name if running esm-compatible cli
+if (/dist-tag-esm/.test(filename) || path.extname(filename) === '.mjs') {
+  name = 'dist-tag-esm'
+}
 
 /**
  * CLI program.
  *
  * @see https://github.com/lukeed/sade#single-command-mode
  *
- * @const {sade.Sade} prog
+ * @const {sade.Sade} program
  */
-const program: sade.Sade = sade([name.split('/')[1], '[target]'].join(' '))
+const program: sade.Sade = sade([name, '[target]'].join(' '))
 
 program
-  .version(version)
+  .version(version) /* c8 ignore stop */
   .describe(description)
   .example('2.0.0')
   .example('2.0.0-alpha.1')

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,6 +951,7 @@ __metadata:
     yaml-eslint-parser: "npm:1.1.0"
   bin:
     dist-tag: ./dist/cli.cjs
+    dist-tag-esm: ./dist/cli.mjs
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

### :pencil: Documentation

- **cli:** `dist-tag-esm`

### :sparkles: Features

- **cli:** `dist-tag-esm`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `dist-tag-esm -h`, `node ./dist/cli.mjs -h`

```zsh
  Description
    Distribution tag lookup utility

  Usage
    $ dist-tag-esm [target] [options]

  Options
    -d, --delimiter    Lookup target separator
    -v, --version      Displays current version
    -h, --help         Displays this message

  Examples
    $ dist-tag-esm 2.0.0
    $ dist-tag-esm 2.0.0-alpha.1
    $ dist-tag-esm foo-package@2.0.0-beta.1 --delimiter @
    $ dist-tag-esm $(git describe --tags --abbrev=0) -d @
```

### `dist-tag -h`, `node ./dist/cli.cjs -h`

```zsh
  Description
    Distribution tag lookup utility

  Usage
    $ dist-tag [target] [options]

  Options
    -d, --delimiter    Lookup target separator
    -v, --version      Displays current version
    -h, --help         Displays this message

  Examples
    $ dist-tag 2.0.0
    $ dist-tag 2.0.0-alpha.1
    $ dist-tag foo-package@2.0.0-beta.1 --delimiter @
    $ dist-tag $(git describe --tags --abbrev=0) -d @
```

### `yarn test:cov`

```zsh
 RUN  v0.21.0

 ✓ src/__tests__/cli.spec.ts > unit:cli > should output "" given []
 ✓ src/__tests__/cli.spec.ts > unit:cli > should output "" given ["2.3.4"]
 ✓ src/__tests__/cli.spec.ts > unit:cli > should output "dev" given ["2.3.4-dev.1"]
 ✓ src/__tests__/cli.spec.ts > unit:cli > should output "alpha" given ["foo@2.3.4-alpha.1", "--delimiter=@"]
 ✓ src/__tests__/cli.spec.ts > unit:cli > should output "beta" given ["foo-package@2.3.4-beta.1", "-d=@"]
 ✓ src/__tests__/node.spec.ts > unit:node > should return "" given []
 ✓ src/__tests__/node.spec.ts > unit:node > should return "" given [{"target": "1.0.0"}]
 ✓ src/__tests__/node.spec.ts > unit:node > should return "" given [{"delimiter": "@", "target": "foo@"}]
 ✓ src/__tests__/node.spec.ts > unit:node > should return "dev" given [{"target": "3.13.98-dev.640"}]
 ✓ src/__tests__/node.spec.ts > unit:node > should return "alpha" given [{"delimiter": "@", "target": "foo-package@1.2.0-alpha.1"}]

Test Files  2 passed (2)
     Tests  10 passed (10)
  Start at  17:00:00
  Duration  6.31s (setup 380ms, collect 16ms, tests 4.54s)

----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |      100 |     100 |     100 |                   
 cli.ts   |     100 |      100 |     100 |     100 |                   
 node.ts  |     100 |      100 |     100 |     100 |                   
----------|---------|----------|---------|---------|-------------------
```

### `yarn build`

```zsh
ℹ Building @flex-development/dist-tag                                                               17:08:22
✔ Build succeeded for @flex-development/dist-tag                                                    17:08:24
  /dist (chunks: 10 files)                                                                          17:08:24
  /dist (chunks: 10 files)                                                                          17:08:24
  /dist (chunks: 10 files)                                                                          17:08:24
  dist/cli.cjs (size: 6.7 kB, exports: )                                                            17:08:24
  dist/cli.mjs (size: 6.6 kB, exports: )                                                            17:08:24
                                                                                                    17:08:24
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

- closes #23

## Submission checklist

- [x] [pr naming conventions][1]
- [x] project was run locally to verify that there are no errors
- [x] documentation added or updated

[1]:
  https://github.com/flex-development/dist-tag/blob/main/CONTRIBUTING.md#pull-request-titles
